### PR TITLE
Updates to support event title truncation and other text modes

### DIFF
--- a/src/webglimpse/timeline/timeline_events_row.ts
+++ b/src/webglimpse/timeline/timeline_events_row.ts
@@ -937,6 +937,7 @@ module Webglimpse {
         rightMargin? : number;
         vAlign? : number;
         spacing? : number;
+        extendBeyondBar?: boolean;
         // One of 'force', 'truncate', or 'show'
         textMode? : string; 
 
@@ -964,6 +965,7 @@ module Webglimpse {
         var rightMargin     = ( hasval( labelOpts ) && hasval( labelOpts.rightMargin     ) ? labelOpts.rightMargin     : 4     );
         var vAlign          = ( hasval( labelOpts ) && hasval( labelOpts.vAlign          ) ? labelOpts.vAlign          : 0.5   );
         var spacing         = ( hasval( labelOpts ) && hasval( labelOpts.spacing         ) ? labelOpts.spacing         : 3     );
+        var extendBeyondBar = ( hasval( labelOpts ) && hasval( labelOpts.extendBeyondBar ) ? labelOpts.extendBeyondBar : false );
         var textMode        = ( hasval( labelOpts ) && hasval( labelOpts.textMode    ) ? labelOpts.textMode    : 'force' );
 
         // Icon options

--- a/src/webglimpse/timeline/timeline_events_row.ts
+++ b/src/webglimpse/timeline/timeline_events_row.ts
@@ -964,7 +964,7 @@ module Webglimpse {
         var rightMargin     = ( hasval( labelOpts ) && hasval( labelOpts.rightMargin     ) ? labelOpts.rightMargin     : 4     );
         var vAlign          = ( hasval( labelOpts ) && hasval( labelOpts.vAlign          ) ? labelOpts.vAlign          : 0.5   );
         var spacing         = ( hasval( labelOpts ) && hasval( labelOpts.spacing         ) ? labelOpts.spacing         : 3     );
-        var textMode        = ( hasval( labelOpts ) && hasval( labelOpts.textMode    ) ? labelOpts.textMode    : 'show' );
+        var textMode        = ( hasval( labelOpts ) && hasval( labelOpts.textMode    ) ? labelOpts.textMode    : 'force' );
 
         // Icon options
         var iconsEnabled     = ( hasval( labelOpts ) && hasval( labelOpts.iconsEnabled     ) ? labelOpts.iconsEnabled     : true   );
@@ -1016,33 +1016,28 @@ module Webglimpse {
                 if ( !( xEnd <= 0 || xStart > 1 ) ) {
                     var xLeft;
                     var xRight;
-                    switch (textMode) {
-                        case 'force':
-                            if (eventIndex + 1 < lane.length) {
-                                var nextEvent = lane.event(eventIndex + 1);
-                                var nextStart_PMILLIS = effectiveEdges_PMILLIS(ui, nextEvent)[0];
-                                xRight = timeAxis.tFrac(nextStart_PMILLIS);
-                            }
-                            else {
-                                xRight = xRightMax;
-                            }
+                    if (textMode === 'force') {
 
-                            if (eventIndex - 1 >= 0) {
-                                var previousEvent = lane.event(eventIndex - 1);
-                                var previousEnd_PMILLIS = effectiveEdges_PMILLIS(ui, previousEvent)[1];
-                                xLeft = timeAxis.tFrac(previousEnd_PMILLIS);
-                            }
-                            else {
-                                xLeft = xLeftMin;
-                            }
-                            break;
-                        case 'show':
-                        // Fall-through
-                        case 'truncate':
-                        // Fall-through
-                        default:
-                            xRight = xEnd;
-                            xLeft = xStart;
+                        if (eventIndex + 1 < lane.length) {
+                            var nextEvent = lane.event(eventIndex + 1);
+                            var nextStart_PMILLIS = effectiveEdges_PMILLIS(ui, nextEvent)[0];
+                            xRight = timeAxis.tFrac(nextStart_PMILLIS);
+                        }
+                        else {
+                            xRight = xRightMax;
+                        }
+
+                        if (eventIndex - 1 >= 0) {
+                            var previousEvent = lane.event(eventIndex - 1);
+                            var previousEnd_PMILLIS = effectiveEdges_PMILLIS(ui, previousEvent)[1];
+                            xLeft = timeAxis.tFrac(previousEnd_PMILLIS);
+                        }
+                        else {
+                            xLeft = xLeftMin;
+                        }
+                    } else {
+                        xRight = xEnd;
+                        xLeft = xStart;
                     }
     
                     // calculate Text width

--- a/src/webglimpse/timeline/timeline_events_row.ts
+++ b/src/webglimpse/timeline/timeline_events_row.ts
@@ -1197,9 +1197,8 @@ module Webglimpse {
         };
     }
 
-    // MJC
     function calculateTextWidth(textEnabled: boolean, labelText: string, fgColor: Color, textDefaultColor: Color,
-        textTextures: Cache<TextTexture2D>, viewport: Bounds) {
+        textTextures: TwoKeyCache<TextTexture2D>, viewport: BoundsUnmodifiable) {
         var wText = 0;
         var textTexture;
         if (textEnabled && labelText) {

--- a/src/webglimpse/timeline/timeline_events_row.ts
+++ b/src/webglimpse/timeline/timeline_events_row.ts
@@ -1043,13 +1043,9 @@ module Webglimpse {
                     }
     
                     // calculate Text width
-                    var wText = 0;
-                    var textTexture;
-                    if ( textEnabled && event.label ) {
-                        var textColor = ( hasval( event.fgColor ) ? event.fgColor : textDefaultColor );
-                        textTexture = textTextures.value( textColor.rgbaString, event.label );
-                        wText = ( textTexture.w / viewport.w );
-                    }
+                    const calculatedTextWidth = calculateTextWidth(textEnabled, event.label, event.fgColor, textDefaultColor, textTextures, viewport);
+                    var wText = calculatedTextWidth.wText;
+                    var textTexture = calculatedTextWidth.textTexture;
                     
                     // calculate Icon width (and start load if necessary)
                     var wIcon = 0;

--- a/src/webglimpse/timeline/timeline_events_row.ts
+++ b/src/webglimpse/timeline/timeline_events_row.ts
@@ -1201,6 +1201,22 @@ module Webglimpse {
         };
     }
 
+    // MJC
+    function calculateTextWidth(textEnabled: boolean, labelText: string, fgColor: Color, textDefaultColor: Color,
+        textTextures: Cache<TextTexture2D>, viewport: Bounds) {
+        var wText = 0;
+        var textTexture;
+        if (textEnabled && labelText) {
+            var textColor = Webglimpse.hasval(fgColor) ? fgColor : textDefaultColor;
+            textTexture = textTextures.value(textColor.rgbaString, labelText);
+            wText = textTexture.w / viewport.w;
+        }
+        return {
+            wText: wText,
+            textTexture: textTexture
+        };
+    }
+
     export function newEventLabelsPainterFactory( labelOpts? : TimelineEventLabelOptions ) : TimelineEventsPainterFactory {
 
         // Painter Factory

--- a/src/webglimpse/timeline/timeline_styles.ts
+++ b/src/webglimpse/timeline/timeline_styles.ts
@@ -101,6 +101,7 @@ module Webglimpse {
                 rightMargin: 2,
                 vAlign: 0.0,
                 spacing: 2,
+                extendBeyondBar: true,
                 textMode: 'force'
             } )
         ]

--- a/src/webglimpse/timeline/timeline_styles.ts
+++ b/src/webglimpse/timeline/timeline_styles.ts
@@ -101,8 +101,7 @@ module Webglimpse {
                 rightMargin: 2,
                 vAlign: 0.0,
                 spacing: 2,
-                forceVisible: false,
-                extendBeyondBar: true
+                textMode: 'force'
             } )
         ]
     } );
@@ -143,7 +142,7 @@ module Webglimpse {
                     rightMargin: 2,
                     vAlign: 0.0,
                     spacing: 2,
-                    forceVisible: true
+                    textMode: 'force'
                 },
                 {
                     bottomMargin: 0,


### PR DESCRIPTION
Updated code to support the three text modes as identified by Geoff Ulman in his email to Paul Lee (excerpt below).

From: Ulman, Geoff [ulman@metsci.com]
Sent: Thursday, September 08, 2016 8:12 AM
Subject: [Non-DoD Source] RE: title truncation
Great! Yeah that's definitely something we should fold into the official release.
I think we would want to retain the capability to specify how text should be treated. We now have three options, and I can imagine cases where they all might be wanted:
1.      Truncate text with insufficient space
2.      Hide text with insufficient space
3.      Allow text to overfill event box
My suggestion would be that we remove the "extendBeyondBar" and "forceVisible" options from TimelineEventLabelOptions (I think it's confusing to have both anyway -- their interactions are non-intuitive) and roll them into one "textMode" option which takes a string:
The options for "textMode" could be:
1.      'force'  :  always print the full text and icon, regardless of available space (what currently happens with 'forceVisible=true')
2.      'truncate'  :  truncate with '…' if insufficient space, if no text will fit, just display icon or nothing (your new functionality)
3.      'show'  :  print the full text if it will fit, otherwise just the icon or nothing (what currently happens with 'forceVisible=false' and 'extendBeyondBar=false')

How does that sound?
Geoff
