### PR TITLE
Branch cache css color

### DIFF
--- a/src/webglimpse/color.ts
+++ b/src/webglimpse/color.ts
@@ -107,17 +107,24 @@ module Webglimpse {
         canvas.width = 1;
         canvas.height = 1;
         var g = canvas.getContext( '2d' );
+        var rgbCache = {};      
         return function( cssColorString : string ) : Color {
             g.clearRect( 0, 0, 1, 1 );
             g.fillStyle = cssColorString;
             g.fillRect( 0, 0, 1, 1 );
 
-            var rgbaData = g.getImageData( 0, 0, 1, 1 ).data;
-            var R = rgbaData[ 0 ] / 255;
-            var G = rgbaData[ 1 ] / 255;
-            var B = rgbaData[ 2 ] / 255;
-            var A = rgbaData[ 3 ] / 255;
-            return rgba( R, G, B, A );
+                var rgbaData;
+                if(!rgbCache[cssColorString]) {
+                    rgbaData = g.getImageData(0, 0, 1, 1).data;
+                    rgbCache[cssColorString] = rgbaData;
+                } else {
+                    rgbaData = rgbCache[cssColorString];
+                }
+                var R = rgbaData[ 0 ] / 255;
+                var G = rgbaData[ 1 ] / 255;
+                var B = rgbaData[ 2 ] / 255;
+                var A = rgbaData[ 3 ] / 255;
+                return rgba( R, G, B, A );
         }
     } )( );
 

--- a/src/webglimpse/color.ts
+++ b/src/webglimpse/color.ts
@@ -112,19 +112,18 @@ module Webglimpse {
             g.clearRect( 0, 0, 1, 1 );
             g.fillStyle = cssColorString;
             g.fillRect( 0, 0, 1, 1 );
-
-                var rgbaData;
-                if(!rgbCache[cssColorString]) {
-                    rgbaData = g.getImageData(0, 0, 1, 1).data;
-                    rgbCache[cssColorString] = rgbaData;
-                } else {
-                    rgbaData = rgbCache[cssColorString];
-                }
-                var R = rgbaData[ 0 ] / 255;
-                var G = rgbaData[ 1 ] / 255;
-                var B = rgbaData[ 2 ] / 255;
-                var A = rgbaData[ 3 ] / 255;
-                return rgba( R, G, B, A );
+            var rgbaData;
+            if(!rgbCache.hasOwnProperty(cssColorString)) {
+                rgbaData = g.getImageData(0, 0, 1, 1).data;
+                rgbCache[cssColorString] = rgbaData;
+            } else {
+                rgbaData = rgbCache[cssColorString];
+            }
+            var R = rgbaData[ 0 ] / 255;
+            var G = rgbaData[ 1 ] / 255;
+            var B = rgbaData[ 2 ] / 255;
+            var A = rgbaData[ 3 ] / 255;
+            return rgba( R, G, B, A );
         }
     } )( );
 


### PR DESCRIPTION
Another approach to speed up the parseCssColor function. Cache the rgba values so that getImageData doesn't have to be called so often.